### PR TITLE
feat: support multiple different types of naming overrides

### DIFF
--- a/charts/blocky/README.md
+++ b/charts/blocky/README.md
@@ -30,6 +30,7 @@ A DNS proxy and ad-blocker for the local network
 | config.yaml | string | `"upstream:\n  default:\n    - 1.1.1.1\n    - 8.8.8.8\nblocking:\n  blackLists:\n    ads:\n      - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts\n  clientGroupsBlock:\n    default:\n      - ads\nport: 53\nhttpPort: 4000\ncaching:\n  minTime: 5m\n  maxTime: 30m\n"` | The configuration for Blocky |
 | fullnameOverride | string | `""` | Optional full name override for the resources |
 | nameOverride | string | `""` | Optional short name override for the resources |
+| namespaceOverride | string | `""` | Optional namespace override for the resources |
 | service.annotations | object | `{}` | Annotations to apply to the Blocky service |
 | service.ports | list | `[{"name":"dns-udp","port":53,"protocol":"UDP"},{"name":"dns-tcp","port":53,"protocol":"TCP"},{"name":"http","port":4000,"protocol":"TCP"}]` | Port to expose the Blocky service on |
 | service.type | string | `"LoadBalancer"` | The type of service to create |

--- a/charts/blocky/templates/_helpers.tpl
+++ b/charts/blocky/templates/_helpers.tpl
@@ -2,14 +2,31 @@
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
 {{- define "blocky.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "blocky.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
 
 {{- define "blocky.image" -}}
 {{- if .Values.blocky.image.tag -}}

--- a/charts/blocky/templates/config_map.yaml
+++ b/charts/blocky/templates/config_map.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "blocky.fullname" . }}-config
   namespace: {{ include "blocky.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "blocky.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.config.annotations }}
   annotations:
     {{- toYaml .Values.config.annotations | nindent 4 }}

--- a/charts/blocky/templates/config_map.yaml
+++ b/charts/blocky/templates/config_map.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "blocky.fullname" . }}-config
-  namespace: blocky
+  namespace: {{ include "blocky.namespace" . }}
   {{- if .Values.config.annotations }}
   annotations:
     {{- toYaml .Values.config.annotations | nindent 4 }}

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "blocky.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   {{ if .Values.blocky.strategyType }}
   strategy:
     type: {{ .Values.blocky.strategyType }}
@@ -16,6 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "blocky.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.blocky.annotations }}
       annotations:
         {{- toYaml .Values.blocky.annotations | nindent 8 }}
@@ -29,6 +31,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: {{ include "blocky.name" . }}
+                    app.kubernetes.io/instance: {{ .Release.Name }}
                 topologyKey: kubernetes.io/hostname
               weight: 100
       {{- end }}

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blocky.fullname" . }}
-  namespace: blocky
+  namespace: {{ include "blocky.namespace" . }}
 spec:
   replicas: {{ .Values.blocky.replicas }}
   selector:

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "blocky.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-  {{ if .Values.blocky.strategyType }}
+  {{- if .Values.blocky.strategyType }}
   strategy:
     type: {{ .Values.blocky.strategyType }}
-  {{ end }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: {{ include "blocky.fullname" . }}
   namespace: {{ include "blocky.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "blocky.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.blocky.replicas }}
   selector:

--- a/charts/blocky/templates/service.yaml
+++ b/charts/blocky/templates/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: {{ include "blocky.fullname" . }}
   namespace: {{ include "blocky.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "blocky.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}

--- a/charts/blocky/templates/service.yaml
+++ b/charts/blocky/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "blocky.fullname" . }}
-  namespace: blocky
+  namespace: {{ include "blocky.namespace" . }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}

--- a/charts/blocky/templates/service.yaml
+++ b/charts/blocky/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/name: {{ include "blocky.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.service.ports }}
   ports:
     {{- range .Values.service.ports }}

--- a/charts/blocky/tests/config_map_test.yaml
+++ b/charts/blocky/tests/config_map_test.yaml
@@ -1,10 +1,11 @@
-suite: test blocky
+suite: test config map
 values:
   - ./values/required-values.yaml
 templates:
   - config_map.yaml
 release:
   name: test
+  namespace: test
 tests:
   - it: should create a ConfigMap
     asserts:

--- a/charts/blocky/tests/deployment_test.yaml
+++ b/charts/blocky/tests/deployment_test.yaml
@@ -45,9 +45,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].name
           value: blocky
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/0xerr0r/blocky:v0.25"
+          pattern: ghcr\.io\/0xerr0r\/blocky:[^".]+
       - notExists:
           path: spec.template.spec.containers[0].resources.limits.cpu
       - equal:

--- a/charts/blocky/tests/deployment_test.yaml
+++ b/charts/blocky/tests/deployment_test.yaml
@@ -33,6 +33,12 @@ tests:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: blocky
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: test
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: test
       - notExists:
           path: spec.template.metadata.annotations
       - exists:

--- a/charts/blocky/tests/deployment_test.yaml
+++ b/charts/blocky/tests/deployment_test.yaml
@@ -5,6 +5,7 @@ templates:
   - deployment.yaml
 release:
   name: test
+  namespace: test
 tests:
   - it: should create a Deployment
     asserts:
@@ -19,7 +20,7 @@ tests:
           value: test-blocky
       - equal:
           path: metadata.namespace
-          value: blocky
+          value: test
       - equal:
           path: spec.replicas
           value: 2
@@ -83,3 +84,33 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["test"]
           value: "true"
+
+  - it: should use only chart name if release name contains chart name
+    documentIndex: 0
+    release:
+      name: blocky
+    asserts:
+      - equal:
+          path: metadata.name
+          value: blocky
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: blocky-config
+
+  - it: respects fullnameOverride
+    documentIndex: 0
+    set:
+      fullnameOverride: "test-fullname"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-fullname
+
+  - it: respects namespaceOverride
+    documentIndex: 0
+    set:
+      namespaceOverride: "test-namespace"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: test-namespace

--- a/charts/blocky/tests/deployment_test.yaml
+++ b/charts/blocky/tests/deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: test blocky
+suite: test deployment
 values:
   - ./values/required-values.yaml
 templates:
@@ -13,7 +13,6 @@ tests:
           count: 1
 
   - it: should create a deployment with correct specifications
-    documentIndex: 0
     asserts:
       - equal:
           path: metadata.name
@@ -83,7 +82,6 @@ tests:
           value: test-blocky-config
 
   - it: can add annotations
-    documentIndex: 0
     set:
       blocky.annotations: {"test": "true"}
     asserts:
@@ -92,7 +90,6 @@ tests:
           value: "true"
 
   - it: should use only chart name if release name contains chart name
-    documentIndex: 0
     release:
       name: blocky
     asserts:
@@ -104,7 +101,6 @@ tests:
           value: blocky-config
 
   - it: respects fullnameOverride
-    documentIndex: 0
     set:
       fullnameOverride: "test-fullname"
     asserts:
@@ -113,7 +109,6 @@ tests:
           value: test-fullname
 
   - it: respects namespaceOverride
-    documentIndex: 0
     set:
       namespaceOverride: "test-namespace"
     asserts:

--- a/charts/blocky/tests/service_test.yaml
+++ b/charts/blocky/tests/service_test.yaml
@@ -1,10 +1,11 @@
-suite: test blocky
+suite: test service
 values:
   - ./values/required-values.yaml
 templates:
   - service.yaml
 release:
   name: test
+  namespace: test
 tests:
   - it: should create Service
     asserts:

--- a/charts/blocky/values.schema.json
+++ b/charts/blocky/values.schema.json
@@ -11,6 +11,10 @@
       "type": "string",
       "description": "Override the full name of the chart"
     },
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Override the namespace of the chart"
+    },
     "blocky": {
       "type": "object",
       "properties": {

--- a/charts/blocky/values.yaml
+++ b/charts/blocky/values.yaml
@@ -2,6 +2,8 @@
 nameOverride: ""
 # -- Optional full name override for the resources
 fullnameOverride: ""
+# -- Optional namespace override for the resources
+namespaceOverride: ""
 
 blocky:
   # -- Annotations to apply to the Blocky pod
@@ -72,4 +74,3 @@ config:
     caching:
       minTime: 5m
       maxTime: 30m
-


### PR DESCRIPTION
This PR adds support for just using the chart name for any resources created, if the release name already contains the chart name, as seen in other charts like the Grafana charts. This avoids ending up with resources named like `blocky-blocky`. This will cause recreation of all resources, hence a breaking change.

Additionally adds support for namespace override, adds some testing around naming overrides and some general refactoring here and there.