### PR TITLE
chore: add ability to configure KubeLinter [skip ci]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,6 +59,7 @@ jobs:
         uses: stackrox/kube-linter-action@v1
         with:
           directory: /tmp/${{ matrix.chart }}
+          config: charts/${{ matrix.chart }}/.kube-linter.yaml
       - name: Create release draft
         if: steps.changed-files.outputs.chart == 'true'
         uses: release-drafter/release-drafter@v6

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,3 +61,4 @@ jobs:
         uses: stackrox/kube-linter-action@v1
         with:
           directory: /tmp/${{ matrix.chart }}
+          config: charts/${{ matrix.chart }}/.kube-linter.yaml


### PR DESCRIPTION
Simple adds a kube-linter.yaml file to Blocky and injects it into the pipeline, allowing to ignore any checks we do not want to enforce on a per-chart level.