### PR TITLE
Update Chart.yaml

### DIFF
--- a/charts/blocky/Chart.yaml
+++ b/charts/blocky/Chart.yaml
@@ -3,7 +3,7 @@ name: blocky
 description: A DNS proxy and ad-blocker for the local network
 type: application
 version: 1.1.2
-appVersion: v0.26
+appVersion: v0.26.2
 keywords:
   - blocky
   - dns


### PR DESCRIPTION
0.26 broke multi arch images, but it is fixed in 0.26.2: https://github.com/0xERR0R/blocky/issues/1776